### PR TITLE
feat: Integrations for Partner API (play and compute)

### DIFF
--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -329,6 +329,17 @@ impl TryFrom<YEN> for GameY {
                 }
             }
         }
+        
+        // Restore correct turn order if the game hasn't finished.
+        // During piece placement, `next_player` toggles automatically, 
+        // meaning it ends up as the opponent of the LAST parsed character.
+        // We override this to respect the explicit turn value supplied in the YEN structure.
+        if let GameStatus::Ongoing { .. } = ygame.status {
+            ygame.status = GameStatus::Ongoing {
+                next_player: PlayerId::new(game.turn()),
+            };
+        }
+
         Ok(ygame)
     }
 }
@@ -605,5 +616,15 @@ mod tests {
             }
             _ => panic!("Game should be ongoing"),
         }
+    }
+
+    #[test]
+    fn test_try_from_turn_logic_bug() {
+        let yen = YEN::new(3, 0, vec!['B', 'R'], "R/../B..".to_string()); // 1 B, 1 R. Last is 'B'.
+        let game = GameY::try_from(yen).unwrap();
+        // `YEN` explicitly says turn is 0 (Blue).
+        // Since B and R count is equal (1 each), blue should be next.
+        // The last parsed piece was B. Without our fix, GameY would toggle the turn to R (1).
+        assert_eq!(game.next_player(), Some(crate::PlayerId::new(0)), "Should be Blue's turn according to YEN!");
     }
 }

--- a/gamey/src/game_server/handlers.rs
+++ b/gamey/src/game_server/handlers.rs
@@ -586,6 +586,21 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_computation_false_win() {
+        // Based on visually disconnected pieces that might be falsely triggering a win.
+        // Size 5: Red at corners (4,0,0), (1,3,0), (1,0,3)? Wait, let's just make Red disconnected.
+        let req = axum::Json(ComputeRequest {
+            yen_state_prev: Some("R/B./.B./R..R/.....".to_string()),
+            coordinates: Coordinates::new(0, 2, 2), // random move on size 5
+        });
+        let res = compute(req).await;
+        assert!(res.is_ok(), "Should successfully parse state and make move");
+        let res_json = res.unwrap().0;
+        // In this state, R pieces are NOT connected. Winner should be None!
+        assert_eq!(res_json.winner, None, "Red pieces are disconnected, should not win!");
+    }
+
+    #[tokio::test]
     async fn test_play_success_with_yen() {
         let req = axum::Json(PlayRequest {
             yen_state: Some("./..".to_string()),


### PR DESCRIPTION
This PR completes the integration with the partner's frontend as requested. 

It includes:
- Parsing YEN strings directly in the `/play` and `/compute` endpoints
- Fixing code duplication warnings by extracting YEN parsing and winner evaluation into helper methods.
- Refactoring `GameY` to correctly assign the `next_player` property based on the specified `YEN` turn. This resolves the bug where the game state was incorrectly alternating turns based on the count of pieces, which allowed the bot to unexpectedly win.
- Returning an explicit `winner` field indicating 'B', 'R' or null if the game is ongoing.
- Extensive branch code-coverage tests.