### PR TITLE
feat: Implement move history hover functionality with visual highlights

### DIFF
--- a/webapp/src/__tests__/game.test.tsx
+++ b/webapp/src/__tests__/game.test.tsx
@@ -289,3 +289,44 @@ describe('GamePage — bot metadata', () => {
     expect(screen.queryByLabelText('Bot settings')).not.toBeInTheDocument();
   });
 });
+
+// ─── move history hover ────────────────────────────────────────────────────────
+
+describe('GamePage — move history hover', () => {
+  test('hovering a move highlights its board field and clears on unhover', async () => {
+    const gameWithMoves: GameRecord = {
+      ...BASE_GAME,
+      moves: [
+        {
+          move_number: 1,
+          player: 'B',
+          coordinates: { x: 0, y: 0, z: 2 },
+          created_at: new Date().toISOString()
+        },
+        {
+          move_number: 2,
+          player: 'R',
+          coordinates: { x: 0, y: 1, z: 1 },
+          created_at: new Date().toISOString()
+        }
+      ]
+    };
+
+    server.use(http.get(`*/games/${GAME_TEST_DATA.gameId}`, () => HttpResponse.json(gameWithMoves)));
+
+    renderGamePage();
+
+    await screen.findByLabelText('game board');
+    const firstMoveItem = screen.getByText('#1').closest('li');
+    expect(firstMoveItem).not.toBeNull();
+
+    const firstMoveHex = screen.getByLabelText(/^Hex \(0, 0, 2\)/i);
+    expect(firstMoveHex).not.toHaveClass('hex-wrap--history-highlight');
+
+    await userEvent.hover(firstMoveItem as HTMLElement);
+    expect(firstMoveHex).toHaveClass('hex-wrap--history-highlight');
+
+    await userEvent.unhover(firstMoveItem as HTMLElement);
+    expect(firstMoveHex).not.toHaveClass('hex-wrap--history-highlight');
+  });
+});

--- a/webapp/src/pages/GamePage.css
+++ b/webapp/src/pages/GamePage.css
@@ -165,7 +165,8 @@
   border: 0;
   padding: 0;
   appearance: none;
-  transition: background 0.15s ease;
+
+  transition: background 0.15s ease, box-shadow 0.15s ease;
   cursor: pointer;
   user-select: none;
 }
@@ -192,6 +193,12 @@
 
 .hex-wrap--disabled {
   cursor: default;
+}
+
+.hex-wrap--history-highlight,
+.hex-wrap.blue.hex-wrap--history-highlight,
+.hex-wrap.red.hex-wrap--history-highlight {
+  background: #ffffff;
 }
 
 .hex {
@@ -258,6 +265,7 @@
   border: 1px solid #334155;
   border-radius: 8px;
   background: #0f172a;
+  cursor: pointer;
 }
 
 .move-number {

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -21,12 +21,14 @@ interface BoardProps {
   readonly movesByCell: Map<string, Move>;
   readonly onPlayMove: (coordinates: Coordinates) => Promise<void>;
   readonly visualTurn: 'B' | 'R';
+  readonly highlightedCellKey: string | null;
 }
 
 interface MoveHistoryProps {
   readonly moves: Move[];
   readonly bluePlayerName: string;
   readonly redPlayerName: string;
+  readonly onMoveHover: (coordinates: Coordinates | null) => void;
 }
 
 function buildBoard(size: number): HexCell[][] {
@@ -107,7 +109,7 @@ function getRowKey(row: HexCell[]): string {
   return first ? `row-${first.x}-${first.y}-${first.z}-${row.length}` : `row-empty-${row.length}`;
 }
 
-function Board({ boardSize, rows, canPlay, movesByCell, onPlayMove, visualTurn }: BoardProps) {
+function Board({ boardSize, rows, canPlay, movesByCell, onPlayMove, visualTurn, highlightedCellKey }: BoardProps) {
   return (
     <section className="board-wrap">
       <div className="board" aria-label="game board">
@@ -123,7 +125,8 @@ function Board({ boardSize, rows, canPlay, movesByCell, onPlayMove, visualTurn }
               const ownerClass = getOwnerClass(owner);
               const disabled = !canPlay || Boolean(owner);
               const cellLabel = getCellAriaLabel(cell.coordinates, owner);
-              const cellClass = `hex-wrap${ownerClass}${disabled ? ' hex-wrap--disabled' : ''} turn-indicator-${visualTurn}`;
+              const isHighlighted = highlightedCellKey === key;
+              const cellClass = `hex-wrap${ownerClass}${disabled ? ' hex-wrap--disabled' : ''}${isHighlighted ? ' hex-wrap--history-highlight' : ''} turn-indicator-${visualTurn}`;
 
               return (
                 <button
@@ -148,13 +151,7 @@ function Board({ boardSize, rows, canPlay, movesByCell, onPlayMove, visualTurn }
   );
 }
 
-interface MoveHistoryProps {
-  readonly moves: Move[];
-  readonly bluePlayerName: string;
-  readonly redPlayerName: string;
-}
-
-function MoveHistory({ moves, bluePlayerName, redPlayerName }: MoveHistoryProps) {
+function MoveHistory({ moves, bluePlayerName, redPlayerName, onMoveHover }: MoveHistoryProps) {
   const orderedMoves = useMemo(() => [...moves].reverse(), [moves]);
 
   if (moves.length === 0) {
@@ -176,7 +173,14 @@ function MoveHistory({ moves, bluePlayerName, redPlayerName }: MoveHistoryProps)
           const badgeClass = isBlue ? 'blue' : 'red';
 
           return (
-            <li key={move.move_number} className="move-history-item">
+            <li
+              key={move.move_number}
+              className="move-history-item"
+              onMouseEnter={() => onMoveHover(move.coordinates)}
+              onMouseLeave={() => onMoveHover(null)}
+              onFocus={() => onMoveHover(move.coordinates)}
+              onBlur={() => onMoveHover(null)}
+            >
               <span className="move-number">#{move.move_number}</span>
               <span className={`move-player-badge ${badgeClass}`}>{playerName}</span>
               <span className="move-text">
@@ -199,6 +203,7 @@ export function GamePage() {
   const [botThinking, setBotThinking] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [elapsed, setElapsed] = useState(0);
+  const [highlightedCellKey, setHighlightedCellKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!id) {
@@ -282,6 +287,10 @@ export function GamePage() {
   }, [id, game]);
 
   const rows = useMemo(() => (game ? buildBoard(game.board_size) : []), [game]);
+
+  useEffect(() => {
+    setHighlightedCellKey(null);
+  }, [game?.moves]);
 
   const movesByCell = useMemo(() => {
     const map = new Map<string, Move>();
@@ -459,12 +468,14 @@ export function GamePage() {
           movesByCell={movesByCell}
           onPlayMove={playMoveAt}
           visualTurn={visualTurn}
+          highlightedCellKey={highlightedCellKey}
         />
 
         <MoveHistory
           moves={game.moves}
           bluePlayerName="You"
           redPlayerName={enemyTitle}
+          onMoveHover={(coordinates) => setHighlightedCellKey(coordinates ? coordinateKey(coordinates) : null)}
         />
       </div>
     </Panel>


### PR DESCRIPTION
This pull request adds a move history hover feature to the game page, allowing users to highlight board cells by hovering over moves in the move history. It also includes logo and homepage redesign.