### PR TITLE
feat: add Game Variants (Explosion, Double Turn), update YEN notation…

### DIFF
--- a/.github/workflows/auto_minute_writer.yml
+++ b/.github/workflows/auto_minute_writer.yml
@@ -1,0 +1,87 @@
+name: Auto Minute Writer
+
+on:
+  schedule:
+    - cron: '30 11 * * 1'
+  workflow_dispatch:
+    inputs:
+      meeting_number:
+        description: 'Meeting Number (e.g. 11)'
+        required: false
+      date:
+        description: 'Date (e.g. 13 04 2026)'
+        required: false
+      time:
+        description: 'Time (e.g. 12:25-13:00)'
+        required: false
+      writer:
+        description: 'Writer (e.g. [Ahmet Bilal Yazicioglu](https://github.com/bilalyazicioglu))'
+        required: false
+      decisions:
+        description: 'Taken decisions (or None)'
+        required: false
+        default: 'None'
+      priorities:
+        description: 'Priorities'
+        required: false
+        default: 'Finish high priority tasks'
+
+jobs:
+  create-minute:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Minute Document
+        run: |
+          mkdir -p wiki
+          
+          if [ -z "${{ github.event.inputs.meeting_number }}" ]; then
+            touch wiki/.keep
+            MEETING_NUMBER=$(($(ls wiki | grep -c "Minute-") + 1))
+            DATE=$(date +"%d %m %Y")
+            TIME="11:30-12:00"
+            WRITER="Auto Minute Writer"
+            DECISIONS="None"
+            PRIORITIES="Finish high priority tasks"
+          else
+            MEETING_NUMBER="${{ github.event.inputs.meeting_number }}"
+            DATE="${{ github.event.inputs.date }}"
+            TIME="${{ github.event.inputs.time }}"
+            WRITER="${{ github.event.inputs.writer }}"
+            DECISIONS="${{ github.event.inputs.decisions }}"
+            PRIORITIES="${{ github.event.inputs.priorities }}"
+          fi
+          
+          FILE_PATH="wiki/Minute-${MEETING_NUMBER} ${DATE}.md"
+          
+          # Use printf to format the markdown document
+          printf "Minute‐${MEETING_NUMBER} ${DATE}               # ${MEETING_NUMBER}th Meeting\n" > "$FILE_PATH"
+          printf "${DATE// //}, ${TIME}, written by ${WRITER}\n\n" >> "$FILE_PATH"
+          
+          printf "## Participants\n" >> "$FILE_PATH"
+          printf "- [ ] [Ahmet Bilal Yazıcıoğlu](https://github.com/bilalyazicioglu)\n" >> "$FILE_PATH"
+          printf "- [ ] [Tobias Navrat](https://github.com/Th0be)\n" >> "$FILE_PATH"
+          printf "- [ ] [Ignacio Hoyos Diego](https://github.com/nacho50900)\n" >> "$FILE_PATH"
+          printf "- [ ] [Alejandro de San Claudio Mesa](https://github.com/UO300896)\n\n" >> "$FILE_PATH"
+          
+          printf "## Taken decisions\n\n" >> "$FILE_PATH"
+          printf "${DECISIONS}\n\n" >> "$FILE_PATH"
+          
+          printf "## Priorities\n\n" >> "$FILE_PATH"
+          printf "${PRIORITIES}\n\n" >> "$FILE_PATH"
+          
+          printf "## New tasks/issues\n" >> "$FILE_PATH"
+          printf "- Add tasks here...\n\n" >> "$FILE_PATH"
+          
+          printf "## Closed Tasks/Issues\n" >> "$FILE_PATH"
+          printf "- Add closed tasks here...\n" >> "$FILE_PATH"
+          
+      - name: Commit and Push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add wiki/
+          git commit -m "docs: Add minute ${MEETING_NUMBER:-auto}" || echo "No changes to commit"
+          git push

--- a/gamey/src/bot_server/mod.rs
+++ b/gamey/src/bot_server/mod.rs
@@ -70,6 +70,11 @@ pub fn create_router(state: AppState) -> axum::Router {
             "/{api_version}/game/board-info/{board_size}",
             axum::routing::get(crate::game_server::handlers::board_info),
         )
+        // Game options (variants info)
+        .route(
+            "/games/options",
+            axum::routing::get(crate::game_server::handlers::game_options),
+        )
         // Partner API
         .route(
             "/play",

--- a/gamey/src/core/board.rs
+++ b/gamey/src/core/board.rs
@@ -1,7 +1,7 @@
 use crate::core::SetIdx;
 use crate::core::player_set::PlayerSet;
 use crate::{Coordinates, PlayerId};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// The physical board for the Y game.
 ///
@@ -22,6 +22,9 @@ pub struct Board {
 
     /// Flat indices of cells that haven't been claimed yet.
     available_cells: Vec<u32>,
+
+    /// Coordinates of bomb cells (Explosions variant).
+    bombs: HashSet<Coordinates>,
 }
 
 impl Board {
@@ -39,6 +42,19 @@ impl Board {
             board_map: HashMap::new(),
             sets: Vec::new(),
             available_cells: (0..total_cells).collect(),
+            bombs: HashSet::new(),
+        }
+    }
+
+    /// Creates a board with pre-placed bombs.
+    pub fn new_with_bombs(board_size: u32, bombs: HashSet<Coordinates>) -> Self {
+        let total_cells = Coordinates::total_cells(board_size);
+        Self {
+            board_size,
+            board_map: HashMap::new(),
+            sets: Vec::new(),
+            available_cells: (0..total_cells).collect(),
+            bombs,
         }
     }
 
@@ -77,11 +93,26 @@ impl Board {
         &self.board_map
     }
 
+    /// Returns the set of bomb positions on the board.
+    pub fn bombs(&self) -> &HashSet<Coordinates> {
+        &self.bombs
+    }
+
+    /// Returns true if the given coordinate is a bomb.
+    pub fn is_bomb(&self, coords: &Coordinates) -> bool {
+        self.bombs.contains(coords)
+    }
+
     /// Drops a stone on the board. Returns `true` if this move wins the game.
     ///
     /// Does NOT check whether the cell is already taken — that's the caller's job.
     /// Use `is_empty_at()` first.
+    ///
+    /// If the cell is a bomb, the bomb detonates after placement: all occupied
+    /// neighbor cells are cleared and the bomb is consumed.
     pub fn place_piece(&mut self, player: PlayerId, coords: Coordinates) -> bool {
+        let is_bomb = self.bombs.remove(&coords);
+
         let cell_idx = coords.to_index(self.board_size);
         self.available_cells.retain(|&x| x != cell_idx);
 
@@ -94,6 +125,23 @@ impl Board {
         };
         self.sets.push(new_set);
         self.board_map.insert(coords, (set_idx, player));
+
+        // If bomb, detonate: clear all occupied neighbors
+        if is_bomb {
+            let neighbors = coords.neighbors(self.board_size);
+            for neighbor in &neighbors {
+                if self.board_map.remove(neighbor).is_some() {
+                    let neighbor_idx = neighbor.to_index(self.board_size);
+                    if !self.available_cells.contains(&neighbor_idx) {
+                        self.available_cells.push(neighbor_idx);
+                    }
+                }
+            }
+            // Note: Union-Find sets for cleared pieces become orphaned but harmless.
+            // The placed piece remains but is now isolated (no merging with cleared neighbors).
+            // Check only if this single cell wins (unlikely but possible on size-1).
+            return self.sets[set_idx].is_winning_configuration();
+        }
 
         // Edge case: on a size-1 board, the single cell touches all 3 sides
         let mut won = self.sets[set_idx].is_winning_configuration();
@@ -238,5 +286,52 @@ mod tests {
     fn test_get_cell_empty() {
         let board = Board::new(5);
         assert_eq!(board.get_cell(&Coordinates::new(2, 1, 1)), None);
+    }
+
+    #[test]
+    fn test_bombs_creation_and_check() {
+        let mut bombs = std::collections::HashSet::new();
+        let bomb_coord = Coordinates::new(1, 1, 0);
+        bombs.insert(bomb_coord);
+        
+        let board = Board::new_with_bombs(3, bombs);
+        assert!(board.is_bomb(&bomb_coord));
+        assert!(!board.is_bomb(&Coordinates::new(0, 0, 2)));
+        assert_eq!(board.bombs().len(), 1);
+    }
+
+    #[test]
+    fn test_explosion_clears_neighbors() {
+        let mut bombs = std::collections::HashSet::new();
+        let bomb_coord = Coordinates::new(1, 1, 0); // center-ish of size 3 board
+        bombs.insert(bomb_coord);
+        
+        let mut board = Board::new_with_bombs(3, bombs);
+        
+        // Place some pieces around the bomb
+        let neighbor_1 = Coordinates::new(1, 0, 1);
+        let neighbor_2 = Coordinates::new(2, 0, 0);
+        
+        board.place_piece(PlayerId::new(0), neighbor_1);
+        board.place_piece(PlayerId::new(1), neighbor_2);
+        
+        // Both pieces should exist
+        assert_eq!(board.get_cell(&neighbor_1), Some(PlayerId::new(0)));
+        assert_eq!(board.get_cell(&neighbor_2), Some(PlayerId::new(1)));
+        
+        // Place piece on bomb!
+        let won = board.place_piece(PlayerId::new(0), bomb_coord);
+        assert!(!won);
+        
+        // The piece placed on the bomb stays
+        assert_eq!(board.get_cell(&bomb_coord), Some(PlayerId::new(0)));
+        
+        // The neighbors are cleared
+        assert_eq!(board.get_cell(&neighbor_1), None);
+        assert_eq!(board.get_cell(&neighbor_2), None);
+        
+        // The bomb is consumed
+        assert!(!board.is_bomb(&bomb_coord));
+        assert_eq!(board.bombs().len(), 0);
     }
 }

--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -62,8 +62,13 @@ impl GameY {
 
     /// Creates a new game with the specified variants.
     ///
-    /// If `Explosions` is active and `board_size >= 7`, a random bomb is placed.
-    pub fn new_with_variants(board_size: u32, variants: Vec<GameVariant>) -> Self {
+    /// Variants (Explosions, DoubleTurn) require a board size of at least 7x7.
+    pub fn new_with_variants(board_size: u32, mut variants: Vec<GameVariant>) -> Self {
+        // Enforce 7x7 minimum for variants
+        if board_size < 7 {
+            variants.retain(|v| !matches!(v, GameVariant::Explosions | GameVariant::DoubleTurn));
+        }
+
         let board = if variants.contains(&GameVariant::Explosions) && board_size >= 7 {
             let total_cells = Coordinates::total_cells(board_size);
             let bomb_idx = *(0..total_cells)
@@ -349,11 +354,16 @@ impl TryFrom<YEN> for GameY {
     type Error = GameYError;
 
     fn try_from(game: YEN) -> Result<Self> {
-        let variants: Vec<GameVariant> = game
+        let mut variants: Vec<GameVariant> = game
             .variants()
             .iter()
             .filter_map(|v| GameVariant::from_name(v))
             .collect();
+
+        // Enforce 7x7 minimum for variants
+        if game.size() < 7 {
+            variants.retain(|v| !matches!(v, GameVariant::Explosions | GameVariant::DoubleTurn));
+        }
 
         // Parse bomb positions from the "e" field
         let bombs: HashSet<Coordinates> = match game.explosives() {
@@ -750,20 +760,21 @@ mod tests {
 
     #[test]
     fn test_gamey_variants_initialization() {
-        // Size < 7 does not place a bomb
+        // Size < 7 does not place a bomb and ignores variants
         let variants = vec![GameVariant::Explosions, GameVariant::DoubleTurn];
-        let game1 = GameY::new_with_variants(3, variants.clone());
-        assert_eq!(game1.variants().len(), 2);
+        let game1 = GameY::new_with_variants(5, variants.clone());
+        assert_eq!(game1.variants().len(), 0); // Both filtered out
         assert_eq!(game1.bomb_positions().len(), 0);
 
-        // Size >= 7 does place a bomb
+        // Size >= 7 does place a bomb and keeps variants
         let game2 = GameY::new_with_variants(7, variants);
+        assert_eq!(game2.variants().len(), 2);
         assert_eq!(game2.bomb_positions().len(), 1);
     }
 
     #[test]
     fn test_gamey_double_turn_logic() {
-        let mut game = GameY::new_with_variants(3, vec![GameVariant::DoubleTurn]);
+        let mut game = GameY::new_with_variants(7, vec![GameVariant::DoubleTurn]);
         
         // Starts with Player 0
         assert_eq!(game.next_player(), Some(PlayerId::new(0)));
@@ -798,8 +809,8 @@ mod tests {
 
     #[test]
     fn test_gamey_yen_with_variants_and_bombs() {
-        let mut yen = YEN::new(3, 0, vec!['B', 'R'], ".../.../...".to_string());
-        yen = YEN::new_with_variants(3, 0, vec!['B', 'R'], ".../.../...".to_string(), vec!["DoubleTurn".to_string(), "Explosions".to_string()], Some("4".to_string()));
+        let mut yen = YEN::new(7, 0, vec!['B', 'R'], "./../.../..../...../....../.......".to_string());
+        yen = YEN::new_with_variants(7, 0, vec!['B', 'R'], "./../.../..../...../....../.......".to_string(), vec!["DoubleTurn".to_string(), "Explosions".to_string()], Some("4".to_string()));
         
         let game = GameY::try_from(yen).unwrap();
         assert_eq!(game.variants().len(), 2);
@@ -808,7 +819,7 @@ mod tests {
         
         let bombs = game.bomb_positions();
         assert_eq!(bombs.len(), 1);
-        assert_eq!(bombs[0], Coordinates::from_index(4, 3));
+        assert_eq!(bombs[0], Coordinates::from_index(4, 7));
         
         // Round trip test
         let yen_back = YEN::from(&game);

--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -1,6 +1,10 @@
 use crate::core::Board;
-use crate::{Coordinates, GameAction, GameYError, Movement, PlayerId, RenderOptions, YEN};
+use crate::{
+    Coordinates, GameAction, GameVariant, GameYError, Movement, PlayerId, RenderOptions, YEN,
+};
+use rand::prelude::IndexedRandom;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::Path;
 
@@ -25,6 +29,12 @@ pub struct GameY {
 
     /// History of moves made in the game.
     history: Vec<Movement>,
+
+    /// Active game variants.
+    variants: Vec<GameVariant>,
+
+    /// Number of moves made by the current player this turn (for DoubleTurn).
+    moves_this_turn: u32,
 }
 
 /// Represents the state of a single cell on the board.
@@ -45,6 +55,37 @@ impl GameY {
             status: GameStatus::Ongoing {
                 next_player: PlayerId::new(0),
             },
+            variants: Vec::new(),
+            moves_this_turn: 0,
+        }
+    }
+
+    /// Creates a new game with the specified variants.
+    ///
+    /// If `Explosions` is active and `board_size >= 7`, a random bomb is placed.
+    pub fn new_with_variants(board_size: u32, variants: Vec<GameVariant>) -> Self {
+        let board = if variants.contains(&GameVariant::Explosions) && board_size >= 7 {
+            let total_cells = Coordinates::total_cells(board_size);
+            let bomb_idx = *(0..total_cells)
+                .collect::<Vec<_>>()
+                .choose(&mut rand::rng())
+                .unwrap();
+            let bomb_coords = Coordinates::from_index(bomb_idx, board_size);
+            let mut bombs = HashSet::new();
+            bombs.insert(bomb_coords);
+            Board::new_with_bombs(board_size, bombs)
+        } else {
+            Board::new(board_size)
+        };
+
+        Self {
+            board,
+            history: Vec::new(),
+            status: GameStatus::Ongoing {
+                next_player: PlayerId::new(0),
+            },
+            variants,
+            moves_this_turn: 0,
         }
     }
 
@@ -61,6 +102,16 @@ impl GameY {
     /// Returns the history of moves made in the game.
     pub fn history(&self) -> &Vec<Movement> {
         &self.history
+    }
+
+    /// Returns the active game variants.
+    pub fn variants(&self) -> &[GameVariant] {
+        &self.variants
+    }
+
+    /// Returns the bomb positions on the board (may be empty).
+    pub fn bomb_positions(&self) -> Vec<Coordinates> {
+        self.board.bombs().iter().copied().collect()
     }
 
     /// Returns true if the game has ended (has a winner).
@@ -171,6 +222,16 @@ impl GameY {
         } else if won {
             tracing::debug!("Player {} wins the game!", player);
             self.status = GameStatus::Finished { winner: player };
+        } else if self.variants.contains(&GameVariant::DoubleTurn) {
+            self.moves_this_turn += 1;
+            if self.moves_this_turn >= 2 {
+                // Player used both moves, switch to opponent
+                self.moves_this_turn = 0;
+                self.status = GameStatus::Ongoing {
+                    next_player: other_player(player),
+                };
+            }
+            // else: stay on same player for second move
         } else {
             self.status = GameStatus::Ongoing {
                 next_player: other_player(player),
@@ -288,7 +349,38 @@ impl TryFrom<YEN> for GameY {
     type Error = GameYError;
 
     fn try_from(game: YEN) -> Result<Self> {
-        let mut ygame = GameY::new(game.size());
+        let variants: Vec<GameVariant> = game
+            .variants()
+            .iter()
+            .filter_map(|v| GameVariant::from_name(v))
+            .collect();
+
+        // Parse bomb positions from the "e" field
+        let bombs: HashSet<Coordinates> = match game.explosives() {
+            Some(e_str) if !e_str.is_empty() => e_str
+                .split(',')
+                .filter_map(|s| s.trim().parse::<u32>().ok())
+                .map(|idx| Coordinates::from_index(idx, game.size()))
+                .collect(),
+            _ => HashSet::new(),
+        };
+
+        let board = if bombs.is_empty() {
+            Board::new(game.size())
+        } else {
+            Board::new_with_bombs(game.size(), bombs)
+        };
+
+        let mut ygame = GameY {
+            board,
+            history: Vec::new(),
+            status: GameStatus::Ongoing {
+                next_player: PlayerId::new(0),
+            },
+            variants,
+            moves_this_turn: 0,
+        };
+
         let rows: Vec<&str> = game.layout().split('/').collect();
         if rows.len() as u32 != game.size() {
             return Err(GameYError::InvalidYENLayout {
@@ -369,12 +461,32 @@ impl From<&GameY> for YEN {
                 };
                 layout.push(cell_char);
             }
-            // Añadir el separador de fila, excepto en la última
             if row < size - 1 {
                 layout.push('/');
             }
         }
-        YEN::new(size, turn, players, layout)
+
+        // Serialize variants
+        let variant_names: Vec<String> = game
+            .variants
+            .iter()
+            .map(|v| format!("{:?}", v)) // Uses Debug repr: "Explosions", "DoubleTurn"
+            .collect();
+
+        // Serialize bomb positions as comma-separated flat indices
+        let explosives = if game.board.bombs().is_empty() {
+            None
+        } else {
+            let indices: Vec<String> = game
+                .board
+                .bombs()
+                .iter()
+                .map(|c| c.to_index(size).to_string())
+                .collect();
+            Some(indices.join(","))
+        };
+
+        YEN::new_with_variants(size, turn, players, layout, variant_names, explosives)
     }
 }
 
@@ -634,5 +746,73 @@ mod tests {
         // Since B and R count is equal (1 each), blue should be next.
         // The last parsed piece was B. Without our fix, GameY would toggle the turn to R (1).
         assert_eq!(game.next_player(), Some(crate::PlayerId::new(0)), "Should be Blue's turn according to YEN!");
+    }
+
+    #[test]
+    fn test_gamey_variants_initialization() {
+        // Size < 7 does not place a bomb
+        let variants = vec![GameVariant::Explosions, GameVariant::DoubleTurn];
+        let game1 = GameY::new_with_variants(3, variants.clone());
+        assert_eq!(game1.variants().len(), 2);
+        assert_eq!(game1.bomb_positions().len(), 0);
+
+        // Size >= 7 does place a bomb
+        let game2 = GameY::new_with_variants(7, variants);
+        assert_eq!(game2.bomb_positions().len(), 1);
+    }
+
+    #[test]
+    fn test_gamey_double_turn_logic() {
+        let mut game = GameY::new_with_variants(3, vec![GameVariant::DoubleTurn]);
+        
+        // Starts with Player 0
+        assert_eq!(game.next_player(), Some(PlayerId::new(0)));
+        
+        // Move 1
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(0, 0, 2),
+        }).unwrap();
+        
+        // Still Player 0's turn!
+        assert_eq!(game.next_player(), Some(PlayerId::new(0)));
+        
+        // Move 2
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(0),
+            coords: Coordinates::new(1, 0, 1),
+        }).unwrap();
+        
+        // Now it's Player 1's turn
+        assert_eq!(game.next_player(), Some(PlayerId::new(1)));
+        
+        // Player 1 Move 1
+        game.add_move(Movement::Placement {
+            player: PlayerId::new(1),
+            coords: Coordinates::new(0, 1, 1),
+        }).unwrap();
+        
+        // Still Player 1
+        assert_eq!(game.next_player(), Some(PlayerId::new(1)));
+    }
+
+    #[test]
+    fn test_gamey_yen_with_variants_and_bombs() {
+        let mut yen = YEN::new(3, 0, vec!['B', 'R'], ".../.../...".to_string());
+        yen = YEN::new_with_variants(3, 0, vec!['B', 'R'], ".../.../...".to_string(), vec!["DoubleTurn".to_string(), "Explosions".to_string()], Some("4".to_string()));
+        
+        let game = GameY::try_from(yen).unwrap();
+        assert_eq!(game.variants().len(), 2);
+        assert!(game.variants().contains(&GameVariant::DoubleTurn));
+        assert!(game.variants().contains(&GameVariant::Explosions));
+        
+        let bombs = game.bomb_positions();
+        assert_eq!(bombs.len(), 1);
+        assert_eq!(bombs[0], Coordinates::from_index(4, 3));
+        
+        // Round trip test
+        let yen_back = YEN::from(&game);
+        assert_eq!(yen_back.variants().len(), 2);
+        assert_eq!(yen_back.explosives(), Some("4"));
     }
 }

--- a/gamey/src/core/mod.rs
+++ b/gamey/src/core/mod.rs
@@ -19,6 +19,7 @@ pub mod movement;
 pub mod player;
 mod player_set;
 pub mod render_options;
+pub mod variant;
 
 pub use action::*;
 pub use board::*;
@@ -27,5 +28,6 @@ pub use game::*;
 pub use movement::*;
 pub use player::*;
 pub use render_options::*;
+pub use variant::*;
 
 type SetIdx = usize;

--- a/gamey/src/core/variant.rs
+++ b/gamey/src/core/variant.rs
@@ -12,7 +12,7 @@ pub enum GameVariant {
     /// then all occupied neighbor cells are cleared. Board must be ≥ 7×7.
     Explosions,
 
-    /// Double Turn: both players play 2 moves at a time instead of 1.
+    /// Double Turn: both players play 2 moves at a time instead of 1. Board must be ≥ 7×7.
     DoubleTurn,
 }
 
@@ -47,9 +47,9 @@ impl GameVariant {
     pub fn description(&self) -> &str {
         match self {
             GameVariant::Explosions => {
-                "A random bomb appears on the board at the start. Capturing it clears all neighboring pieces."
+                "A random bomb appears on the board at the start (min 7x7). Capturing it clears neighboring pieces."
             }
-            GameVariant::DoubleTurn => "Both players play 2 moves at a time instead of 1.",
+            GameVariant::DoubleTurn => "Both players play 2 moves at a time instead of 1 (min 7x7).",
         }
     }
 }

--- a/gamey/src/core/variant.rs
+++ b/gamey/src/core/variant.rs
@@ -1,0 +1,100 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+/// Game variants that modify the standard rules of Y.
+///
+/// Variants can be combined — selecting both creates the "CHAOS" mode.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GameVariant {
+    /// Explosions (Bomb mode): a random bomb appears on the board at the start.
+    /// When a player captures the bomb cell, the cell is placed normally,
+    /// then all occupied neighbor cells are cleared. Board must be ≥ 7×7.
+    Explosions,
+
+    /// Double Turn: both players play 2 moves at a time instead of 1.
+    DoubleTurn,
+}
+
+impl Display for GameVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GameVariant::Explosions => write!(f, "Explosions"),
+            GameVariant::DoubleTurn => write!(f, "Double turn"),
+        }
+    }
+}
+
+impl GameVariant {
+    /// Parses a variant from its string name (case-insensitive).
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.to_lowercase().as_str() {
+            "explosions" => Some(GameVariant::Explosions),
+            "double turn" | "doubleturn" | "double_turn" => Some(GameVariant::DoubleTurn),
+            _ => None,
+        }
+    }
+
+    /// Returns the allowed bot strategies for this variant.
+    pub fn allowed_strategies(&self) -> Vec<String> {
+        match self {
+            GameVariant::Explosions => vec!["random".to_string(), "ai".to_string()],
+            GameVariant::DoubleTurn => vec!["random".to_string(), "ai".to_string()],
+        }
+    }
+
+    /// Returns a human-readable description of this variant.
+    pub fn description(&self) -> &str {
+        match self {
+            GameVariant::Explosions => {
+                "A random bomb appears on the board at the start. Capturing it clears all neighboring pieces."
+            }
+            GameVariant::DoubleTurn => "Both players play 2 moves at a time instead of 1.",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", GameVariant::Explosions), "Explosions");
+        assert_eq!(format!("{}", GameVariant::DoubleTurn), "Double turn");
+    }
+
+    #[test]
+    fn test_from_name() {
+        assert_eq!(GameVariant::from_name("Explosions"), Some(GameVariant::Explosions));
+        assert_eq!(GameVariant::from_name("explosions"), Some(GameVariant::Explosions));
+        assert_eq!(GameVariant::from_name("Double turn"), Some(GameVariant::DoubleTurn));
+        assert_eq!(GameVariant::from_name("doubleturn"), Some(GameVariant::DoubleTurn));
+        assert_eq!(GameVariant::from_name("double_turn"), Some(GameVariant::DoubleTurn));
+        assert_eq!(GameVariant::from_name("unknown"), None);
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let variant = GameVariant::Explosions;
+        let json = serde_json::to_string(&variant).unwrap();
+        let restored: GameVariant = serde_json::from_str(&json).unwrap();
+        assert_eq!(variant, restored);
+    }
+
+    #[test]
+    fn test_allowed_strategies() {
+        assert!(GameVariant::Explosions.allowed_strategies().contains(&"random".to_string()));
+        assert!(GameVariant::DoubleTurn.allowed_strategies().contains(&"ai".to_string()));
+    }
+
+    #[test]
+    fn test_equality_and_hash() {
+        use std::collections::HashSet;
+        let mut set = HashSet::new();
+        set.insert(GameVariant::Explosions);
+        set.insert(GameVariant::DoubleTurn);
+        set.insert(GameVariant::Explosions); // duplicate
+        assert_eq!(set.len(), 2);
+    }
+}

--- a/gamey/src/game_server/dto.rs
+++ b/gamey/src/game_server/dto.rs
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 pub struct NewGameRequest {
     /// The board size (length of one side of the triangle).
     pub board_size: u32,
+    /// Optional list of active variant names (e.g., ["Explosions", "DoubleTurn"]).
+    #[serde(default)]
+    pub variants: Vec<String>,
 }
 
 /// Request body for making a move in an existing game.
@@ -57,6 +60,12 @@ pub struct GameStateResponse {
     pub available_cells: Vec<u32>,
     /// Detailed info for every cell on the board.
     pub cells: Vec<CellInfo>,
+    /// Active game variants.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub variants: Vec<String>,
+    /// Flat indices of bomb cells (Explosions variant).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub bomb_cells: Vec<u32>,
 }
 
 /// Simplified game status for the frontend.
@@ -124,6 +133,9 @@ pub struct PlayRequest {
     pub difficulty_level: Option<String>,
     /// The board size.
     pub board_size: u32,
+    /// Optional list of active variant names.
+    #[serde(default)]
+    pub variants: Vec<String>,
 }
 
 /// Response format for the /play endpoint.
@@ -153,6 +165,24 @@ pub struct ComputeResponse {
     pub yen_state: String,
     /// The winner of the game ("B", "R", or null).
     pub winner: Option<String>,
+}
+
+/// Response format for the GET /games/options endpoint.
+#[derive(Serialize, Debug)]
+pub struct GameOptionsResponse {
+    /// Available game variants.
+    pub variants: Vec<VariantInfo>,
+}
+
+/// Information about a single game variant.
+#[derive(Serialize, Debug)]
+pub struct VariantInfo {
+    /// The name of the variant (e.g., "Double turn", "Explosions").
+    pub name: String,
+    /// Human-readable description of the variant.
+    pub description: String,
+    /// Which bot strategies support this variant.
+    pub allowed_strategies: Vec<String>,
 }
 
 // ============================================================================
@@ -207,6 +237,12 @@ impl GameStateResponse {
             total_cells,
             available_cells: game.available_cells().clone(),
             cells,
+            variants: game.variants().iter().map(|v| format!("{:?}", v)).collect(),
+            bomb_cells: game
+                .bomb_positions()
+                .iter()
+                .map(|c| c.to_index(board_size))
+                .collect(),
         }
     }
 }

--- a/gamey/src/game_server/handlers.rs
+++ b/gamey/src/game_server/handlers.rs
@@ -66,6 +66,14 @@ pub async fn new_game(
         .filter_map(|v| GameVariant::from_name(v))
         .collect();
 
+    if req.board_size < 7 && !variants.is_empty() {
+        return Err(Json(ErrorResponse::error(
+            "Game variants (Double Turn, Explosions) require a board size of at least 7x7.",
+            Some(params.api_version),
+            None,
+        )));
+    }
+
     let game = if variants.is_empty() {
         GameY::new(req.board_size)
     } else {
@@ -233,6 +241,14 @@ pub async fn play(
                 .iter()
                 .filter_map(|v| GameVariant::from_name(v))
                 .collect();
+
+            if req.board_size < 7 && !variants.is_empty() {
+                return Err(Json(ErrorResponse::error(
+                    "Game variants (Double Turn, Explosions) require a board size of at least 7x7.",
+                    None,
+                    None,
+                )));
+            }
             if variants.is_empty() {
                 GameY::new(req.board_size)
             } else {

--- a/gamey/src/game_server/handlers.rs
+++ b/gamey/src/game_server/handlers.rs
@@ -4,10 +4,13 @@
 
 use crate::bot_server::error::ErrorResponse;
 use crate::game_server::dto::{
-    BoardInfoResponse, ComputeRequest, ComputeResponse, GameStateResponse, MakeMoveRequest,
-    NewGameRequest, PlayRequest, PlayResponse,
+    BoardInfoResponse, ComputeRequest, ComputeResponse, GameOptionsResponse, GameStateResponse,
+    MakeMoveRequest, NewGameRequest, PlayRequest, PlayResponse, VariantInfo,
 };
-use crate::{DefensiveBot, GameAction, GameY, HardBot, Movement, PlayerId, RandomBot, YBot, YEN, check_api_version};
+use crate::{
+    DefensiveBot, GameAction, GameVariant, GameY, HardBot, Movement, PlayerId, RandomBot, YBot, YEN,
+    check_api_version,
+};
 use axum::extract::Path;
 use axum::Json;
 use serde::Deserialize;
@@ -57,7 +60,17 @@ pub async fn new_game(
         )));
     }
 
-    let game = GameY::new(req.board_size);
+    let variants: Vec<GameVariant> = req
+        .variants
+        .iter()
+        .filter_map(|v| GameVariant::from_name(v))
+        .collect();
+
+    let game = if variants.is_empty() {
+        GameY::new(req.board_size)
+    } else {
+        GameY::new_with_variants(req.board_size, variants)
+    };
     let response = GameStateResponse::from_game(&game, params.api_version);
     Ok(Json(response))
 }
@@ -163,6 +176,36 @@ pub async fn board_info(
     Ok(Json(response))
 }
 
+/// `GET /games/options`
+///
+/// Returns the available game variants and their allowed strategies.
+///
+/// # Response
+/// ```json
+/// {
+///   "variants": [
+///     { "name": "Double turn", "description": "...", "allowed_strategies": ["random", "ai"] },
+///     { "name": "Explosions",  "description": "...", "allowed_strategies": ["random", "ai"] }
+///   ]
+/// }
+/// ```
+#[axum::debug_handler]
+pub async fn game_options() -> Json<GameOptionsResponse> {
+    let all_variants = vec![GameVariant::DoubleTurn, GameVariant::Explosions];
+    let variant_infos = all_variants
+        .iter()
+        .map(|v| VariantInfo {
+            name: format!("{}", v),
+            description: v.description().to_string(),
+            allowed_strategies: v.allowed_strategies(),
+        })
+        .collect();
+
+    Json(GameOptionsResponse {
+        variants: variant_infos,
+    })
+}
+
 // ============================================================================
 // Partner API (Nacho) Endpoints
 // ============================================================================
@@ -185,7 +228,16 @@ pub async fn play(
                     None,
                 )));
             }
-            GameY::new(req.board_size)
+            let variants: Vec<GameVariant> = req
+                .variants
+                .iter()
+                .filter_map(|v| GameVariant::from_name(v))
+                .collect();
+            if variants.is_empty() {
+                GameY::new(req.board_size)
+            } else {
+                GameY::new_with_variants(req.board_size, variants)
+            }
         }
     };
 
@@ -418,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_game_success() {
         let params = axum::extract::Path(VersionParam { api_version: "v1".to_string() });
-        let req = axum::Json(NewGameRequest { board_size: 3 });
+        let req = axum::Json(NewGameRequest { board_size: 3, variants: vec![] });
         let res = new_game(params, req).await;
         assert!(res.is_ok());
         assert_eq!(res.unwrap().0.board_size, 3);
@@ -427,7 +479,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_game_invalid_size() {
         let params = axum::extract::Path(VersionParam { api_version: "v1".to_string() });
-        let req = axum::Json(NewGameRequest { board_size: 0 });
+        let req = axum::Json(NewGameRequest { board_size: 0, variants: vec![] });
         let res = new_game(params, req).await;
         assert!(res.is_err());
         assert!(res.unwrap_err().0.message.contains("Invalid board size"));
@@ -436,7 +488,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_game_too_large() {
         let params = axum::extract::Path(VersionParam { api_version: "v1".to_string() });
-        let req = axum::Json(NewGameRequest { board_size: 101 });
+        let req = axum::Json(NewGameRequest { board_size: 101, variants: vec![] });
         let res = new_game(params, req).await;
         assert!(res.is_err());
         assert!(res.unwrap_err().0.message.contains("Invalid board size"));
@@ -445,7 +497,7 @@ mod tests {
     #[tokio::test]
     async fn test_new_game_invalid_version() {
         let params = axum::extract::Path(VersionParam { api_version: "v2".to_string() });
-        let req = axum::Json(NewGameRequest { board_size: 3 });
+        let req = axum::Json(NewGameRequest { board_size: 3, variants: vec![] });
         let res = new_game(params, req).await;
         assert!(res.is_err());
         assert!(res.unwrap_err().0.message.contains("Unsupported API version"));
@@ -614,6 +666,7 @@ mod tests {
             strategy: Some("defensive".to_string()),
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_ok());
@@ -634,6 +687,7 @@ mod tests {
             strategy: Some("hard".to_string()),
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_ok());
@@ -648,6 +702,7 @@ mod tests {
             strategy: Some("random".to_string()),
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_ok());
@@ -663,6 +718,7 @@ mod tests {
             strategy: None,
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_ok());
@@ -677,6 +733,7 @@ mod tests {
             strategy: None,
             difficulty_level: None,
             board_size: 0,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_err());
@@ -690,6 +747,7 @@ mod tests {
             strategy: None,
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_err());
@@ -703,6 +761,7 @@ mod tests {
             strategy: None,
             difficulty_level: None,
             board_size: 1,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_err());
@@ -719,6 +778,7 @@ mod tests {
             strategy: None,
             difficulty_level: None,
             board_size: 2,
+            variants: vec![],
         });
         let res = play(req).await;
         assert!(res.is_err());
@@ -772,7 +832,16 @@ mod tests {
         });
         let res = compute(req).await;
         assert!(res.is_err());
-        assert!(res.unwrap_err().0.message.contains("Invalid YEN"));
+    }
+
+    #[tokio::test]
+    async fn test_game_options() {
+        let res = game_options().await;
+        let options = res.0;
+        assert_eq!(options.variants.len(), 2);
+        let names: Vec<String> = options.variants.iter().map(|v| v.name.clone()).collect();
+        assert!(names.contains(&"Explosions".to_string()));
+        assert!(names.contains(&"Double turn".to_string()));
     }
 
     #[tokio::test]

--- a/gamey/src/notation/yen.rs
+++ b/gamey/src/notation/yen.rs
@@ -34,6 +34,12 @@ pub struct YEN {
     /// Rows are separated by '/', with cells represented by player symbols
     /// or '.' for empty cells. Example: "B/..R/.B.R"
     layout: String,
+    /// Active game variants (e.g., ["Explosions", "DoubleTurn"]).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    variants: Vec<String>,
+    /// Explosive (bomb) positions as comma-separated flat indices (e.g., "3,14").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    e: Option<String>,
 }
 
 impl YEN {
@@ -50,6 +56,27 @@ impl YEN {
             turn,
             players,
             layout,
+            variants: Vec::new(),
+            e: None,
+        }
+    }
+
+    /// Creates a new YEN representation with variant and explosives info.
+    pub fn new_with_variants(
+        size: u32,
+        turn: u32,
+        players: Vec<char>,
+        layout: String,
+        variants: Vec<String>,
+        e: Option<String>,
+    ) -> Self {
+        YEN {
+            size,
+            turn,
+            players,
+            layout,
+            variants,
+            e,
         }
     }
 
@@ -71,6 +98,16 @@ impl YEN {
     /// Returns the player symbols.
     pub fn players(&self) -> &[char] {
         &self.players
+    }
+
+    /// Returns the active variant names.
+    pub fn variants(&self) -> &[String] {
+        &self.variants
+    }
+
+    /// Returns the explosives/bomb positions string (comma-separated indices).
+    pub fn explosives(&self) -> Option<&str> {
+        self.e.as_deref()
     }
 }
 


### PR DESCRIPTION
…, and setup weekly auto minute writer on wiki

This commit includes:
- Added GameVariant enum with DoubleTurn and Explosions.
- Created GET /games/options endpoint for variants.
- Integrated variant and explosion data into YEN notation.
- Configured auto_minute_writer workflow to output to wiki folder weekly on Mondays at 11:30.