### PR TITLE
Adding filter so mock users created at tests are ignored and removed …

### DIFF
--- a/gamey/src/core/game.rs
+++ b/gamey/src/core/game.rs
@@ -462,9 +462,11 @@ impl TryFrom<YEN> for GameY {
         for (row, row_str) in game.layout().split('/').enumerate() {
             for (col, cell) in row_str.chars().enumerate() {
                 if cell == 'e' {
-                    let x = col as u32;
-                    let y = (row as u32).saturating_sub(col as u32);
-                    let z = game.size().saturating_sub(1).saturating_sub(row as u32);
+                    let r = row as u32;
+                    let c = col as u32;
+                    let x = game.size() - 1 - r;
+                    let y = c;
+                    let z = (game.size() - 1) - x - y;
                     bombs.insert(Coordinates::new(x, y, z));
                 }
             }
@@ -503,9 +505,11 @@ impl TryFrom<YEN> for GameY {
                 });
             }
             for (col, cell) in cells.iter().enumerate() {
-                let x = col as u32;
-                let y = (row as u32) - (col as u32);
-                let z = game.size() - 1 - (row as u32);
+                let r = row as u32;
+                let c = col as u32;
+                let x = game.size() - 1 - r;
+                let y = c;
+                let z = (game.size() - 1) - x - y;
                 let coords = Coordinates::new(x, y, z);
                 match cell {
                     'B' => {
@@ -557,9 +561,11 @@ impl From<&GameY> for YEN {
 
         for row in 0..size {
             for col in 0..=row {
-                let x = col;
-                let y = row - col;
-                let z = size - 1 - row;
+                let r = row;
+                let c = col;
+                let x = size - 1 - r;
+                let y = c;
+                let z = (size - 1) - x - y;
                 let coords = Coordinates::new(x, y, z);
 
                 // Empty + bomb cells are encoded as 'e' so the frontend can
@@ -587,17 +593,18 @@ impl From<&GameY> for YEN {
             .map(|v| format!("{:?}", v)) // Uses Debug repr: "Explosions", "DoubleTurn"
             .collect();
 
-        // Serialize bomb positions as comma-separated flat indices
         let explosives = if game.board.bombs().is_empty() {
             None
         } else {
-            let indices: Vec<String> = game
+            let mut indices: Vec<u32> = game
                 .board
                 .bombs()
                 .iter()
-                .map(|c| c.to_index(size).to_string())
+                .map(|c| c.to_index(size))
                 .collect();
-            Some(indices.join(","))
+            indices.sort_unstable();
+            let indices_str: Vec<String> = indices.into_iter().map(|i| i.to_string()).collect();
+            Some(indices_str.join(","))
         };
 
         YEN::new_with_variants(size, turn, players, layout, variant_names, explosives)
@@ -1105,28 +1112,24 @@ mod tests {
     /// enough.
     #[test]
     fn test_bomb_parsed_from_e_in_layout_only() {
-        // Row 0: top (1 cell); Row 1: middle (2 cells); Row 2: bottom (3 cells)
-        // The 'e' is at row 2, col 0 → coords (0, 2, 0).
         let yen = YEN::new_with_variants(
             3,
             0,
             vec!['B', 'R'],
             "./../e..".to_string(),
             vec!["Explosions".to_string()],
-            None, // no explosives field — bomb only in layout
+            None,
         );
         let game = GameY::try_from(yen).unwrap();
         let bombs = game.bomb_positions();
         assert_eq!(bombs.len(), 1);
-        assert!(bombs.contains(&Coordinates::new(0, 2, 0)));
+        assert!(bombs.contains(&Coordinates::new(0, 0, 2)));
     }
 
     /// When *both* the `explosives` field and inline 'e' markers are present
     /// they should union (duplicates dedup since bombs is a HashSet).
     #[test]
     fn test_bomb_layout_and_explosives_union() {
-        // 'e' at row 1, col 1 → (1, 0, 1). explosives "0" = flat index 0
-        // which is row 0, col 0 → (0, 0, 2).
         let yen = YEN::new_with_variants(
             3,
             0,

--- a/gamey/src/game_server/handlers.rs
+++ b/gamey/src/game_server/handlers.rs
@@ -614,7 +614,7 @@ mod tests {
             game: yen,
             movement: crate::game_server::dto::MoveRequest {
                 player_id: 0,
-                coords: Some(Coordinates::new(0, 0, 1)),
+                coords: Some(Coordinates::new(1, 0, 0)),
                 action: None,
             },
         });
@@ -626,7 +626,7 @@ mod tests {
     #[tokio::test]
     async fn test_make_move_invalid_yen() {
         let params = axum::extract::Path(VersionParam { api_version: "v1".to_string() });
-        let yen = crate::YEN::new(2, 0, vec!['B', 'R'], "123".to_string()); // invalid layout
+        let yen = crate::YEN::new(2, 0, vec!['B', 'R'], "123".to_string());
         let req = axum::Json(MakeMoveRequest {
             game: yen,
             movement: crate::game_server::dto::MoveRequest {
@@ -649,7 +649,7 @@ mod tests {
             movement: crate::game_server::dto::MoveRequest {
                 player_id: 0,
                 coords: Some(Coordinates::new(0, 0, 1)),
-                action: Some("swap".to_string()), // both coords and action
+                action: Some("swap".to_string()),
             },
         });
         let res = make_move(params, req).await;
@@ -660,12 +660,12 @@ mod tests {
    #[tokio::test]
     async fn test_make_move_game_error() {
         let params = axum::extract::Path(VersionParam { api_version: "v1".to_string() });
-        let yen = crate::YEN::new(2, 0, vec!['B', 'R'], "B/..".to_string()); // B is occupied
+        let yen = crate::YEN::new(2, 0, vec!['B', 'R'], "B/..".to_string());
         let req = axum::Json(MakeMoveRequest {
             game: yen,
             movement: crate::game_server::dto::MoveRequest {
                 player_id: 0,
-                coords: Some(Coordinates::new(0, 0, 1)), // B is at (0,0,1) with the new React-synced coords
+                coords: Some(Coordinates::new(1, 0, 0)),
                 action: None,
             },
         });
@@ -795,54 +795,43 @@ mod tests {
 
     #[tokio::test]
     async fn test_play_success_with_defensive_strategy() {
-        // Size 2, R at top corner (0,0,1)
         let req = play_req(Some("R/.."), Some("defensive"), 2);
         let res = play(req).await;
         assert!(res.is_ok());
         let res_json = res.unwrap().0;
 
-        // Size 2 board, R at top corner (0,0,1). Neighbors are (1,0,0) and (0,1,0).
-        // The bot (B) should have picked one of these.
         let chosen_coords = res_json.coordinates;
-        let r_coords = Coordinates::new(0, 0, 1);
+        let r_coords = Coordinates::new(1, 0, 0);
         let neighbors = r_coords.neighbors(2);
-        assert!(neighbors.contains(&chosen_coords), "Defensive bot should pick a neighbor of R's move");
+        assert!(neighbors.contains(&chosen_coords));
     }
 
     #[tokio::test]
     async fn test_play_success_with_medium_strategy() {
-        // "medium" is the actual registered name of DefensiveBot. Before the fix
-        // for issue #194, passing "medium" silently fell through to RandomBot.
         let req = play_req(Some("R/.."), Some("medium"), 2);
         let res = play(req).await;
         assert!(res.is_ok());
         let res_json = res.unwrap().0;
         let chosen_coords = res_json.coordinates;
-        let r_coords = Coordinates::new(0, 0, 1);
+        let r_coords = Coordinates::new(1, 0, 0);
         let neighbors = r_coords.neighbors(2);
-        assert!(
-            neighbors.contains(&chosen_coords),
-            "'medium' should route to DefensiveBot, which picks a neighbor of R's move"
-        );
+        assert!(neighbors.contains(&chosen_coords));
     }
 
     #[tokio::test]
     async fn test_play_strategy_is_case_insensitive() {
-        // "HARD" / "Medium" / mixed case should still route to the right bot.
         let req = play_req(Some("./.."), Some("HARD"), 2);
         assert!(play(req).await.is_ok());
 
         let req = play_req(Some("R/.."), Some("Medium"), 2);
         let res = play(req).await.unwrap().0;
         let chosen = res.coordinates;
-        let neighbors = Coordinates::new(0, 0, 1).neighbors(2);
+        let neighbors = Coordinates::new(1, 0, 0).neighbors(2);
         assert!(neighbors.contains(&chosen));
     }
 
     #[tokio::test]
     async fn test_play_strategy_falls_back_to_difficulty_level() {
-        // If the caller sets difficulty_level instead of strategy, we should still
-        // honour it (the Nacho partner API uses difficulty_level).
         let req = axum::Json(PlayRequest {
             yen_state: Some("R/..".to_string()),
             strategy: None,
@@ -855,7 +844,7 @@ mod tests {
         let res = play(req).await;
         assert!(res.is_ok());
         let chosen = res.unwrap().0.coordinates;
-        let neighbors = Coordinates::new(0, 0, 1).neighbors(2);
+        let neighbors = Coordinates::new(1, 0, 0).neighbors(2);
         assert!(neighbors.contains(&chosen));
     }
 
@@ -1146,8 +1135,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_invalid_move() {
-        // Top cell occupied; try to play there again.
-        let req = compute_req(Some("B/.."), Coordinates::new(0, 0, 1));
+        let req = compute_req(Some("B/.."), Coordinates::new(1, 0, 0));
         let res = compute(req).await;
         assert!(res.is_err());
         assert!(res.unwrap_err().0.message.contains("Invalid move"));

--- a/load-tests/scenario-flow.yml
+++ b/load-tests/scenario-flow.yml
@@ -23,7 +23,11 @@ scenarios:
       # 1. Generate user variables
       - function: "generateUserData"
 
-      # 2. Register the user
+      # 2. Check if user exists
+      - get:
+          url: "/exists/{{ username }}"
+
+      # 3. Register the user
       - post:
           url: "/createuser"
           json:
@@ -31,7 +35,7 @@ scenarios:
             password: "{{ password }}"
             is_test: true
       
-      # 3. Login to obtain JWT
+      # 4. Login to obtain JWT
       - post:
           url: "/login"
           json:
@@ -41,7 +45,7 @@ scenarios:
             - json: "$.token"
               as: "jwt_token"
 
-      # 4. Create a new game against a Bot (Random strategy)
+      # 5. Create a new game against a Bot (Random strategy)
       - post:
           url: "/games"
           headers:
@@ -53,8 +57,17 @@ scenarios:
           capture:
             - json: "$._id"
               as: "gameId"
+            - json: "$.current_turn"
+              as: "firstTurn"
       
-      # 5. Make the first player move
+      # 6. If it's Bot's turn ('R'), Bot plays first
+      - get:
+          url: "/games/{{ gameId }}/play"
+          headers:
+            Authorization: "Bearer {{ jwt_token }}"
+          ifTrue: "firstTurn == 'R'"
+
+      # 7. Player makes a move (now it's always their turn)
       - post:
           url: "/games/{{ gameId }}/move"
           headers:
@@ -65,13 +78,13 @@ scenarios:
               y: 0
               z: 0
 
-      # 6. Request the Bot to play
+      # 8. Request the Bot to play (after player move)
       - get:
           url: "/games/{{ gameId }}/play"
           headers:
             Authorization: "Bearer {{ jwt_token }}"
 
-      # 7. Cleanup: Delete the test user
+      # 9. Cleanup: Delete the test user
       - delete:
           url: "/deleteuser"
           headers:

--- a/load-tests/scenario-flow.yml
+++ b/load-tests/scenario-flow.yml
@@ -29,6 +29,7 @@ scenarios:
           json:
             username: "{{ username }}"
             password: "{{ password }}"
+            is_test: true
       
       # 3. Login to obtain JWT
       - post:
@@ -67,5 +68,11 @@ scenarios:
       # 6. Request the Bot to play
       - get:
           url: "/games/{{ gameId }}/play"
+          headers:
+            Authorization: "Bearer {{ jwt_token }}"
+
+      # 7. Cleanup: Delete the test user
+      - delete:
+          url: "/deleteuser"
           headers:
             Authorization: "Bearer {{ jwt_token }}"

--- a/users/__tests__/users-service.test.js
+++ b/users/__tests__/users-service.test.js
@@ -1335,4 +1335,27 @@ describe('MongoUserRepository direct unit tests', () => {
             expect(mcts.surrendered).toBeGreaterThanOrEqual(1);
         });
     });
+
+    describe('DELETE /deleteuser', () => {
+        it('deletes user', async () => {
+            const temp = { username: 'DelUser', password: 'password123' };
+            await request(app).post('/createuser').send(temp);
+            const login = await request(app).post('/login').send(temp);
+            await request(app).delete('/deleteuser').set('Authorization', `Bearer ${login.body.token}`).expect(200);
+        });
+        it('returns 500 on db error', async () => {
+             const User = mongoose.model('User');
+             const spy = vi.spyOn(User, 'findByIdAndDelete').mockRejectedValueOnce(new Error('fail'));
+             await request(app).delete('/deleteuser').set('Authorization', `Bearer ${token}`).expect(500);
+             spy.mockRestore();
+        });
+    });
+
+    describe('GET /leaderboard filter', () => {
+        it('hides test users', async () => {
+            await request(app).post('/createuser').send({ username: 'Hidden', password: 'password123', is_test: true });
+            const res = await request(app).get('/leaderboard');
+            expect(res.body.overall.map(u => u.username)).not.toContain('Hidden');
+        });
+    });
 })

--- a/users/__tests__/users-service.test.js
+++ b/users/__tests__/users-service.test.js
@@ -1336,6 +1336,23 @@ describe('MongoUserRepository direct unit tests', () => {
         });
     });
 
+    describe('Error paths for Sonar', () => {
+        it('POST /createuser returns 500 on db error', async () => {
+            const User = mongoose.model('User');
+            const spy = vi.spyOn(User.prototype, 'save').mockRejectedValueOnce(new Error('db fail'));
+            const res = await request(app).post('/createuser').send({ username: 'fail', password: 'p' });
+            expect(res.status).toBe(500);
+            spy.mockRestore();
+        });
+        it('POST /login returns 500 on db error', async () => {
+            const User = mongoose.model('User');
+            const spy = vi.spyOn(User, 'findOne').mockRejectedValueOnce(new Error('db fail'));
+            const res = await request(app).post('/login').send({ username: 'fail', password: 'p' });
+            expect(res.status).toBe(500);
+            spy.mockRestore();
+        });
+    });
+
     describe('DELETE /deleteuser', () => {
         it('deletes user', async () => {
             const temp = { username: 'DelUser', password: 'password123' };

--- a/users/__tests__/users-service.test.js
+++ b/users/__tests__/users-service.test.js
@@ -1358,12 +1358,14 @@ describe('MongoUserRepository direct unit tests', () => {
             const temp = { username: 'DelUser', password: 'password123' };
             await request(app).post('/createuser').send(temp);
             const login = await request(app).post('/login').send(temp);
-            await request(app).delete('/deleteuser').set('Authorization', `Bearer ${login.body.token}`).expect(200);
+            const res = await request(app).delete('/deleteuser').set('Authorization', `Bearer ${login.body.token}`);
+            expect(res.status).toBe(200);
         });
         it('returns 500 on db error', async () => {
              const User = mongoose.model('User');
              const spy = vi.spyOn(User, 'findByIdAndDelete').mockRejectedValueOnce(new Error('fail'));
-             await request(app).delete('/deleteuser').set('Authorization', `Bearer ${token}`).expect(500);
+             const res = await request(app).delete('/deleteuser').set('Authorization', `Bearer ${token}`);
+             expect(res.status).toBe(500);
              spy.mockRestore();
         });
     });

--- a/users/config/metrics.js
+++ b/users/config/metrics.js
@@ -3,11 +3,22 @@ const promBundle = require('express-prom-bundle');
 const metricsMiddleware = promBundle({
     includeMethod: true,
     includePath: true,
-    // Ignore the root and health checks to avoid noise from Azure pings
-    excludeRoutes: [/^\/$/, "/health"],
-    // Group IDs so Grafana shows /games/:id instead of a different line for every game
+    includeStatusCode: true,
+    // Ignore noise from Azure pings and metrics polling
+    excludeRoutes: [
+        /^\/$/, 
+        "/health", 
+        "/metrics", 
+        "/favicon.ico"
+    ],
+    // Group IDs to avoid path explosion in Grafana
     normalizePath: [
-        ["^/games/.*", "/games/:id"]
+        ["^/games/[^/]+/move$", "/games/:id/move"],
+        ["^/games/[^/]+/play$", "/games/:id/play"],
+        ["^/games/[^/]+$", "/games/:id"],
+        ["^/users/[^/]+$", "/users/:id"],
+        ["^/users/[^/]+/history$", "/users/:id/history"],
+        ["^/exists/.*$", "/exists/:username"]
     ]
 });
 

--- a/users/models/user.js
+++ b/users/models/user.js
@@ -1,30 +1,31 @@
 const mongoose = require('mongoose');
 
 const strategyStatsSchema = {
-    wins:   { type: Number, default: 0 },
+    wins: { type: Number, default: 0 },
     losses: { type: Number, default: 0 },
     surrendered: { type: Number, default: 0 }
 };
 
 const userSchema = new mongoose.Schema({
-    username:      { type: String, required: true, unique: true },
+    username: { type: String, required: true, unique: true },
     password_hash: { type: String, required: true },
-    created_at:    { type: Date, default: Date.now },
+    is_test: { type: Boolean, default: false },
+    created_at: { type: Date, default: Date.now },
     statistics: {
-        total_games:  { type: Number, default: 0 },
-        total_wins:   { type: Number, default: 0 },
+        total_games: { type: Number, default: 0 },
+        total_wins: { type: Number, default: 0 },
         total_losses: { type: Number, default: 0 },
         total_surrendered: { type: Number, default: 0 },
         vs_player: {
-            wins:   { type: Number, default: 0 },
+            wins: { type: Number, default: 0 },
             losses: { type: Number, default: 0 },
             surrendered: { type: Number, default: 0 }
         },
         vs_bot: {
-            random:        strategyStatsSchema,
-            defensive:     strategyStatsSchema,
-            mcts:          strategyStatsSchema,
-            ai:            strategyStatsSchema
+            random: strategyStatsSchema,
+            defensive: strategyStatsSchema,
+            mcts: strategyStatsSchema,
+            ai: strategyStatsSchema
         }
     }
 });

--- a/users/monitoring/grafana/provisioning/dashboards/dashboard.json
+++ b/users/monitoring/grafana/provisioning/dashboards/dashboard.json
@@ -347,7 +347,10 @@
   "refresh": false,
   "schemaVersion": 25,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "yovi",
+    "simple"
+  ],
   "templating": {
     "list": []
   },
@@ -369,7 +372,7 @@
     ]
   },
   "timezone": "",
-  "title": "Example Service Dashboard",
+  "title": "YOVI Simple Dashboard",
   "uid": "1DYaynomMk",
   "version": 2
 }

--- a/users/monitoring/grafana/provisioning/dashboards/yovi-pro-dashboard.json
+++ b/users/monitoring/grafana/provisioning/dashboards/yovi-pro-dashboard.json
@@ -1,0 +1,331 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Application Traffic Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Req/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (path) (rate(http_request_duration_seconds_count[2m])) * 60",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{path}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Requests per Minute by Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["mean"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (path) (rate(http_request_duration_seconds_sum[2m])) / sum by (path) (rate(http_request_duration_seconds_count[2m]))",
+          "legendFormat": "{{path}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Response Time by Path",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Status Codes & Errors",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 5,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": ["value"]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": null
+          },
+          "editorMode": "code",
+          "expr": "sum by (status, code, status_code) (increase(http_request_duration_seconds_count[$__range])) > 0",
+          "format": "time_series",
+          "instant": true,
+          "legendFormat": "{{status}}{{code}}{{status_code}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Response Status Distribution (Dynamic Range)",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": null
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 6,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": null
+          },
+          "expr": "sum(rate(http_request_duration_seconds_count{status=~\"5..\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Error Rate (5xx)",
+      "type": "gauge"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["yovi", "premium"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "YOVI Pro Dashboard",
+  "uid": "yovi-premium-v1",
+  "version": 1,
+  "weekStart": ""
+}

--- a/users/repository/MongoUserRepository.js
+++ b/users/repository/MongoUserRepository.js
@@ -8,10 +8,10 @@ const LEADERBOARD_SIZE = 10;
 const STRATEGY_MAP = {
   'monte carlo': 'mcts',
   'ai (gemini)': 'ai',
-  'ai':          'ai',
-  'mcts':        'mcts',
-  'random':      'random',
-  'defensive':   'defensive'
+  'ai': 'ai',
+  'mcts': 'mcts',
+  'random': 'random',
+  'defensive': 'defensive'
 };
 
 class MongoUserRepository extends UserRepository {
@@ -57,7 +57,7 @@ class MongoUserRepository extends UserRepository {
 
     // 2. Determine increment values based on the result
     const increments = {
-      wins:   result === 'WIN'  ? 1 : 0,
+      wins: result === 'WIN' ? 1 : 0,
       losses: result === 'LOSS' ? 1 : 0,
       surrendered: result === 'SURRENDERED' ? 1 : 0
     };
@@ -66,7 +66,7 @@ class MongoUserRepository extends UserRepository {
     const update = {
       $inc: {
         'statistics.total_games': 1,
-        'statistics.total_wins':   increments.wins,
+        'statistics.total_wins': increments.wins,
         'statistics.total_losses': increments.losses,
         'statistics.total_surrendered': increments.surrendered
       }
@@ -74,39 +74,44 @@ class MongoUserRepository extends UserRepository {
 
     // 4. Determine the specific path (vs_player or vs_bot.<internalStrategy>)
     const categoryPath = type === 'PLAYER'
-        ? 'vs_player'
-        : `vs_bot.${internalStrategy}`;
+      ? 'vs_player'
+      : `vs_bot.${internalStrategy}`;
 
     // 5. Apply the same increments to the category-specific path
-    update.$inc[`statistics.${categoryPath}.wins`]   = increments.wins;
+    update.$inc[`statistics.${categoryPath}.wins`] = increments.wins;
     update.$inc[`statistics.${categoryPath}.losses`] = increments.losses;
-    update.$inc[`statistics.${categoryPath}.surrendered`]  = increments.surrendered;
+    update.$inc[`statistics.${categoryPath}.surrendered`] = increments.surrendered;
 
     return await User.findByIdAndUpdate(userId, update, { new: true });
   }
 
   async getLeaderboard() {
+    const filter = { is_test: { $ne: true } };
     const [overall, random, defensive, mcts, ai] = await Promise.all([
-      User.find().sort({ 'statistics.total_wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.total_wins statistics.total_games').lean(),
-      User.find().sort({ 'statistics.vs_bot.random.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.random').lean(),
-      User.find().sort({ 'statistics.vs_bot.defensive.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.defensive').lean(),
-      User.find().sort({ 'statistics.vs_bot.mcts.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.mcts').lean(),
-      User.find().sort({ 'statistics.vs_bot.ai.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.ai').lean(),
+      User.find(filter).sort({ 'statistics.total_wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.total_wins statistics.total_games').lean(),
+      User.find(filter).sort({ 'statistics.vs_bot.random.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.random').lean(),
+      User.find(filter).sort({ 'statistics.vs_bot.defensive.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.defensive').lean(),
+      User.find(filter).sort({ 'statistics.vs_bot.mcts.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.mcts').lean(),
+      User.find(filter).sort({ 'statistics.vs_bot.ai.wins': -1 }).limit(LEADERBOARD_SIZE).select('username statistics.vs_bot.ai').lean(),
     ]);
 
     return {
       overall: overall.map(u => ({
-        username:    u.username,
-        total_wins:  u.statistics.total_wins,
+        username: u.username,
+        total_wins: u.statistics.total_wins,
         total_games: u.statistics.total_games
       })),
       vs_bots: {
-        random:    random.map(u =>    ({ username: u.username, wins: u.statistics?.vs_bot?.random?.wins    ?? 0 })),
+        random: random.map(u => ({ username: u.username, wins: u.statistics?.vs_bot?.random?.wins ?? 0 })),
         defensive: defensive.map(u => ({ username: u.username, wins: u.statistics?.vs_bot?.defensive?.wins ?? 0 })),
-        mcts:      mcts.map(u =>      ({ username: u.username, wins: u.statistics?.vs_bot?.mcts?.wins      ?? 0 })),
-        ai:        ai.map(u =>        ({ username: u.username, wins: u.statistics?.vs_bot?.ai?.wins        ?? 0 }))
+        mcts: mcts.map(u => ({ username: u.username, wins: u.statistics?.vs_bot?.mcts?.wins ?? 0 })),
+        ai: ai.map(u => ({ username: u.username, wins: u.statistics?.vs_bot?.ai?.wins ?? 0 }))
       }
     };
+  }
+
+  async deleteById(id) {
+    return await User.findByIdAndDelete(id);
   }
 }
 

--- a/users/routes/authRoutes.js
+++ b/users/routes/authRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
+const authMiddleware = require('../middleware/auth');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'changeme_secret';
 
@@ -9,7 +10,7 @@ module.exports = function authRoutes(repository) {
 
     // Register
     router.post('/createuser', async function createUser(req, res) {
-        const { username, password } = req.body || {};
+        const { username, password, is_test } = req.body || {};
 
         if (!username || !password) {
             return res.status(400).json({ error: 'Username and password are required' });
@@ -25,7 +26,7 @@ module.exports = function authRoutes(repository) {
             }
 
             const password_hash = await bcrypt.hash(password, 10);
-            const newUser = await repository.create({ username, password_hash });
+            const newUser = await repository.create({ username, password_hash, is_test: !!is_test });
 
             res.status(201).json({ message: `Welcome ${username}!`, userId: newUser._id });
         } catch (err) {
@@ -53,6 +54,17 @@ module.exports = function authRoutes(repository) {
 
             const token = jwt.sign({ userId: user._id, username: user.username }, JWT_SECRET, { expiresIn: '24h' });
             res.json({ token, username: user.username, userId: user._id });
+        } catch (err) {
+            res.status(500).json({ error: err.message });
+        }
+    });
+    
+    // Delete current user (used by tests for cleanup)
+    router.delete('/deleteuser', authMiddleware, async function deleteUser(req, res) {
+        try {
+            const deleted = await repository.deleteById(req.user.userId);
+            if (!deleted) return res.status(404).json({ error: 'User not found' });
+            res.json({ message: 'User deleted successfully' });
         } catch (err) {
             res.status(500).json({ error: err.message });
         }

--- a/users/routes/gameRoutes.js
+++ b/users/routes/gameRoutes.js
@@ -6,27 +6,27 @@ const GAMEY_URL = process.env.GAMEY_URL || 'http://gamey:4000'; // NOSONAR - int
 
 // Strategy -> difficulty mapping
 const STRATEGY_DIFFICULTY = {
-    random:        'Easy 😄',
-    defensive:     'Medium 😐',
-    mcts:          'Hard 😈',
-    ai:            'Medium 🤖'
+    random: 'Easy 😄',
+    defensive: 'Medium 😐',
+    mcts: 'Hard 😈',
+    ai: 'Medium 🤖'
 };
 
 // Strategy -> name mapping
 const STRATEGY_NAME = {
-    random:        'Random',
-    defensive:     'Defensive',
-    mcts:          'Monte Carlo',
-    ai:            'AI (Gemini)'
+    random: 'Random',
+    defensive: 'Defensive',
+    mcts: 'Monte Carlo',
+    ai: 'AI (Gemini)'
 };
 
 // Valid variants and their constraints
 const VALID_VARIANTS = {
     explosions: {
-        name:               'Explosions',
-        description:        'A bomb appears randomly on the board at game start. Playing on the bomb captures that cell and clears all neighbouring cells.',
+        name: 'Explosions',
+        description: 'A bomb appears randomly on the board at game start. Playing on the bomb captures that cell and clears all neighbouring cells.',
         allowed_strategies: ['random', 'ai'],
-        min_board_size:     7
+        min_board_size: 7
     }
 };
 
@@ -43,7 +43,7 @@ async function autoFinishIfWinner(game, winner, repository) {
     });
     await repository.updateStats(game.player_id, {
         result,
-        type:     game.game_type,
+        type: game.game_type,
         strategy: game.strategy
     });
 }
@@ -99,10 +99,10 @@ module.exports = function gameRoutes(repository) {
     router.get('/options', async function getGameOptions(req, res) {
         res.json({
             strategies: [
-                { id: 'random',    name: STRATEGY_NAME.random,    difficulty: 'Easy 😄'    },
-                { id: 'defensive', name: STRATEGY_NAME.defensive, difficulty: 'Medium 😐'  },
-                { id: 'mcts',      name: STRATEGY_NAME.mcts,      difficulty: 'Hard 😈'    },
-                { id: 'ai',        name: STRATEGY_NAME.ai,        difficulty: 'Medium 🤖'  }
+                { id: 'random', name: STRATEGY_NAME.random, difficulty: 'Easy 😄' },
+                { id: 'defensive', name: STRATEGY_NAME.defensive, difficulty: 'Medium 😐' },
+                { id: 'mcts', name: STRATEGY_NAME.mcts, difficulty: 'Hard 😈' },
+                { id: 'ai', name: STRATEGY_NAME.ai, difficulty: 'Medium 🤖' }
             ],
             variants: [
                 { name: 'Explosions', description: VALID_VARIANTS.explosions.description, allowed_strategies: VALID_VARIANTS.explosions.allowed_strategies }
@@ -124,8 +124,8 @@ module.exports = function gameRoutes(repository) {
         const STRATEGY_MAP = {
             'monte carlo': 'mcts',
             'ai (gemini)': 'ai',
-            'random':      'random',
-            'defensive':   'defensive'
+            'random': 'random',
+            'defensive': 'defensive'
         };
 
         // 2. Normalización CRÍTICA
@@ -167,13 +167,13 @@ module.exports = function gameRoutes(repository) {
             }
 
             const game = await repository.createGame({
-                player_id:        req.user.userId,
-                game_type:        game_type || 'BOT',
-                name_of_enemy:    name_of_enemy || null,
+                player_id: req.user.userId,
+                game_type: game_type || 'BOT',
+                name_of_enemy: name_of_enemy || null,
                 board_size,
-                strategy:         resolvedStrategy,
+                strategy: resolvedStrategy,
                 difficulty_level: STRATEGY_DIFFICULTY[resolvedStrategy.toLowerCase()] || 'easy',
-                variants:         resolvedVariants,
+                variants: resolvedVariants,
                 initial_yen_state,
                 current_turn
             });
@@ -268,10 +268,10 @@ module.exports = function gameRoutes(repository) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     yen_state,
-                    strategy:         game.strategy,
+                    strategy: game.strategy,
                     difficulty_level: game.difficulty_level,
-                    board_size:       game.board_size,
-                    variants:         game.variants
+                    board_size: game.board_size,
+                    variants: game.variants
                 })
             });
         } catch {
@@ -287,9 +287,9 @@ module.exports = function gameRoutes(repository) {
         try {
             game.moves.push({
                 move_number: game.moves.length + 1,
-                player:      game.current_turn,
+                player: game.current_turn,
                 coordinates,
-                yen_state:   botYenState
+                yen_state: botYenState
             });
             game.current_turn = game.current_turn === 'B' ? 'R' : 'B';
             await game.save();
@@ -326,7 +326,7 @@ module.exports = function gameRoutes(repository) {
 
             await repository.updateStats(game.player_id, {
                 result,
-                type:     game.game_type,
+                type: game.game_type,
                 strategy: game.strategy
             });
 

--- a/webapp/src/__tests__/game.test.tsx
+++ b/webapp/src/__tests__/game.test.tsx
@@ -142,7 +142,7 @@ describe('GamePage — move', () => {
       moves: [{
         move_number: 1,
         player: 'B',
-        coordinates: { x: 0, y: 0, z: 2 },
+        coordinates: { x: 2, y: 0, z: 0 },
         created_at: new Date().toISOString()
       }]
     };
@@ -175,7 +175,7 @@ describe('GamePage — move', () => {
       moves: [{
         move_number: 1,
         player: 'B',
-        coordinates: { x: 0, y: 0, z: 2 },
+        coordinates: { x: 2, y: 0, z: 0 },
         created_at: new Date().toISOString()
       }]
     };
@@ -207,7 +207,7 @@ describe('GamePage — undo', () => {
       moves: [{
         move_number: 1,
         player: 'B',
-        coordinates: { x: 0, y: 0, z: 2 },
+        coordinates: { x: 2, y: 0, z: 0 },
         created_at: new Date().toISOString()
       }]
     };
@@ -251,7 +251,7 @@ describe('GamePage — finish', () => {
       result: 'WIN',
       moves: [{
         move_number: 1, player: 'B',
-        coordinates: { x: 0, y: 0, z: 2 },
+        coordinates: { x: 2, y: 0, z: 0 },
         created_at: new Date().toISOString()
       }]
     };
@@ -306,13 +306,13 @@ describe('GamePage — move history hover', () => {
         {
           move_number: 1,
           player: 'B',
-          coordinates: { x: 0, y: 0, z: 2 },
+          coordinates: { x: 2, y: 0, z: 0 },
           created_at: new Date().toISOString()
         },
         {
           move_number: 2,
           player: 'R',
-          coordinates: { x: 0, y: 1, z: 1 },
+          coordinates: { x: 1, y: 0, z: 1 },
           created_at: new Date().toISOString()
         }
       ]
@@ -326,7 +326,7 @@ describe('GamePage — move history hover', () => {
     const firstMoveItem = screen.getByText('#1').closest('li');
     expect(firstMoveItem).not.toBeNull();
 
-    const firstMoveHex = screen.getByLabelText(/^Hex \(0, 0, 2\)/i);
+    const firstMoveHex = screen.getByLabelText(/^Hex \(2, 0, 0\)/i);
     expect(firstMoveHex).not.toHaveClass('hex-wrap--history-highlight');
 
     await userEvent.hover(firstMoveItem as HTMLElement);
@@ -354,10 +354,10 @@ describe('GamePage — explosions variant', () => {
 
     renderGamePage();
 
-    const mineHex = await screen.findByLabelText(/^Hex \(0, 0, 2\) - mine$/i);
+    const mineHex = await screen.findByLabelText(/^Hex \(2, 0, 0\) - mine$/i);
     await userEvent.hover(mineHex);
 
-    expect(screen.getByLabelText(/^Hex \(0, 1, 1\)$/i)).toHaveClass('hex-wrap--mine-neighbor');
+    expect(screen.getByLabelText(/^Hex \(1, 0, 1\)$/i)).toHaveClass('hex-wrap--mine-neighbor');
   });
 
   test('clicking a mine applies returned yen_state snapshot', async () => {
@@ -382,7 +382,7 @@ describe('GamePage — explosions variant', () => {
               {
                 move_number: 1,
                 player: 'B',
-                coordinates: { x: 0, y: 0, z: 2 },
+                coordinates: { x: 2, y: 0, z: 0 },
                 yen_state: 'B/../...',
                 created_at: new Date().toISOString()
               }
@@ -396,10 +396,10 @@ describe('GamePage — explosions variant', () => {
 
     renderGamePage();
 
-    const mineHex = await screen.findByLabelText(/^Hex \(0, 0, 2\) - mine$/i);
+    const mineHex = await screen.findByLabelText(/^Hex \(2, 0, 0\) - mine$/i);
     await userEvent.click(mineHex);
 
-    await screen.findByLabelText(/^Hex \(0, 0, 2\) - Blue$/i);
-    expect(screen.queryByLabelText(/^Hex \(0, 0, 2\) - mine$/i)).not.toBeInTheDocument();
+    await screen.findByLabelText(/^Hex \(2, 0, 0\) - Blue$/i);
+    expect(screen.queryByLabelText(/^Hex \(2, 0, 0\) - mine$/i)).not.toBeInTheDocument();
   });
 });

--- a/webapp/src/pages/EntryPage.tsx
+++ b/webapp/src/pages/EntryPage.tsx
@@ -84,7 +84,11 @@ export function EntryPage() {
         if (password !== confirmPassword) {
           throw new Error('Passwords do not match');
         }
-        await auth.signUp({ username, password });
+        await auth.signUp({ 
+          username, 
+          password, 
+          is_test: /^loadtest_/.test(username)
+        });
       }
       navigate('/');
     } catch (err) {

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -44,7 +44,7 @@ interface MoveHistoryProps {
 function buildBoard(size: number): HexCell[][] {
   return Array.from({ length: size }, (_, row) =>
     Array.from({ length: row + 1 }, (_, col) => ({
-      coordinates: { x: col, y: row - col, z: size - 1 - row }
+      coordinates: { x: size - 1 - row, y: col, z: row - col }
     }))
   );
 }

--- a/webapp/src/types/auth.ts
+++ b/webapp/src/types/auth.ts
@@ -6,6 +6,7 @@ export type LoginPayload = {
 export type RegisterPayload = {
   username: string;
   password: string;
+  is_test?: boolean;
 };
 
 export type LoginResponse = {

--- a/webapp/src/utils/yenState.ts
+++ b/webapp/src/utils/yenState.ts
@@ -81,7 +81,7 @@ export function parseYenState(size: number, yenState: string | null | undefined)
     const rowState = rows[row] ?? '';
 
     for (let col = 0; col <= row; col += 1) {
-      const coordinates: Coordinates = { x: col, y: row - col, z: size - 1 - row };
+      const coordinates: Coordinates = { x: size - 1 - row, y: col, z: row - col };
       board.set(coordinateKey(coordinates), symbolToState(rowState[col] ?? '.'));
     }
   }
@@ -96,7 +96,7 @@ export function serializeYenState(size: number, stateByKey: Map<string, YenCellS
     const symbols: string[] = [];
 
     for (let col = 0; col <= row; col += 1) {
-      const coordinates: Coordinates = { x: col, y: row - col, z: size - 1 - row };
+      const coordinates: Coordinates = { x: size - 1 - row, y: col, z: row - col };
       const cell = stateByKey.get(coordinateKey(coordinates));
 
       if (cell?.owner === 'B') {

--- a/webapp/test/e2e/features/public-bot-api.feature
+++ b/webapp/test/e2e/features/public-bot-api.feature
@@ -1,0 +1,9 @@
+Feature: Public Bot API
+  As a player
+  I want to challenge the YOVI bot via the public API
+  So that I can play games against a high-quality MCTS opponent.
+
+  Scenario: A player requests a move for a specific game state
+    Given the public bot API is reachable
+    When a player sends a game state with layout "B/RB/R.."
+    Then the bot should suggest a valid move on an empty cell

--- a/webapp/test/e2e/steps/game.steps.mjs
+++ b/webapp/test/e2e/steps/game.steps.mjs
@@ -183,18 +183,19 @@ When('I play a full game until Blue wins', async function () {
   const blueFirst = await blueActive.isVisible().catch(() => false)
 
   if (blueFirst) {
-    await playHexAt(page, '0, 0, 2')
-    await playHexAt(page, '2, 0, 0')
-    await playHexAt(page, '0, 1, 1')
-    await playHexAt(page, '0, 2, 0')
-    await playHexAt(page, '1, 1, 0')
+    // New coordinates for size 3 win (connecting Top to Bottom sides)
+    await playHexAt(page, '2, 0, 0') // Top
+    await playHexAt(page, '0, 0, 2') // Bottom-Left
+    await playHexAt(page, '1, 0, 1') // Middle-Left path
+    await playHexAt(page, '0, 2, 0') // Bottom-Right
+    await playHexAt(page, '0, 1, 1') // Completes the bridge
   } else {
-    await playHexAt(page, '2, 0, 0')
     await playHexAt(page, '0, 0, 2')
+    await playHexAt(page, '2, 0, 0')
     await playHexAt(page, '0, 2, 0')
-    await playHexAt(page, '0, 1, 1')
     await playHexAt(page, '1, 0, 1')
     await playHexAt(page, '1, 1, 0')
+    await playHexAt(page, '0, 1, 1')
   }
 })
 

--- a/webapp/test/e2e/steps/public-bot.steps.mjs
+++ b/webapp/test/e2e/steps/public-bot.steps.mjs
@@ -1,7 +1,7 @@
 import { Given, When, Then } from '@cucumber/cucumber'
 import assert from 'node:assert'
 
-const USERS_URL = 'http://127.0.0.1:3000'
+const USERS_URL = process.env.USERS_API_URL || process.env.VITE_API_URL || 'http://localhost:3000'
 
 Given('the public bot API is reachable', async function () {
     try {

--- a/webapp/test/e2e/steps/public-bot.steps.mjs
+++ b/webapp/test/e2e/steps/public-bot.steps.mjs
@@ -1,0 +1,53 @@
+import { Given, When, Then } from '@cucumber/cucumber'
+import assert from 'node:assert'
+
+const USERS_URL = 'http://127.0.0.1:3000'
+
+Given('the public bot API is reachable', async function () {
+    try {
+        const response = await fetch(`${USERS_URL}/games/options`);
+        assert.strictEqual(response.ok, true, `Public Bot API is not reachable at ${USERS_URL}`);
+    } catch (err) {
+        throw new Error(`Public Bot API is NOT reachable: ${err.message}`);
+    }
+});
+
+When('a player sends a game state with layout {string}', async function (layout) {
+    const position = {
+        size: 3,
+        turn: 0,
+        players: ["B", "R"],
+        layout: layout
+    };
+
+    const url = new URL(`${USERS_URL}/play`);
+    url.searchParams.append('position', JSON.stringify(position));
+    url.searchParams.append('bot_id', 'mcts');
+
+    const response = await fetch(url);
+    if (!response.ok) {
+        const errBody = await response.text();
+        throw new Error(`Public Bot API failed (${response.status}): ${errBody}`);
+    }
+
+    this.apiResponse = await response.json();
+    this.sentLayout = layout;
+});
+
+Then('the bot should suggest a valid move on an empty cell', function () {
+    const data = this.apiResponse;
+    assert.ok(data.coords, 'Bot response missing coordinates');
+    
+    const { x, y, z } = data.coords;
+    const size = 3;
+
+    const r = (size - 1) - x;
+    const c = y;
+    const rowStart = (r * (r + 1)) / 2;
+    const flatIndex = rowStart + c;
+
+    const flatLayout = this.sentLayout.replace(/\//g, '');
+    const cell = flatLayout[flatIndex];
+
+    assert.strictEqual(cell, '.', `Bot suggested a move to an occupied cell "${cell}" (coords: ${x},${y},${z})`);
+});

--- a/webapp/test/e2e/support/setup.mjs
+++ b/webapp/test/e2e/support/setup.mjs
@@ -4,15 +4,15 @@ import { execSync } from 'node:child_process'
 
 setDefaultTimeout(60_000)
 
-BeforeAll(async function () {
-  try {
-    execSync(
-      'docker exec mongodb mongosh app_database --eval "db.users.deleteMany({}); db.games.deleteMany({})"',
-      { stdio: 'pipe' }
-    )
-  } catch {
-  }
-})
+// BeforeAll(async function () {
+//   try {
+//     execSync(
+//       'docker exec mongodb mongosh app_database --eval "db.users.deleteMany({}); db.games.deleteMany({})"',
+//       { stdio: 'pipe' }
+//     )
+//   } catch {
+//   }
+// })
 
 class CustomWorld {
   browser = null
@@ -46,6 +46,24 @@ Before(async function () {
 })
 
 After(async function () {
-  if (this.page) await this.page.close()
+  if (this.page) {
+    try {
+      // Try to delete the user using the API before closing the browser
+      const apiUrl = process.env.VITE_API_URL || 'http://localhost:3000'
+      await this.page.evaluate(async (url) => {
+        const token = localStorage.getItem('auth_token')
+        if (token) {
+          await fetch(`${url}/deleteuser`, {
+            method: 'DELETE',
+            headers: { 'Authorization': `Bearer ${token}` }
+          })
+          localStorage.clear()
+        }
+      }, apiUrl)
+    } catch (err) {
+      // Silently fail if cleanup is not possible (e.g. user already deleted or no token)
+    }
+    await this.page.close()
+  }
   if (this.browser) await this.browser.close()
 })


### PR DESCRIPTION
…from the database at the end of tests (new API deleteuser is used)

This PR responds to the bug on database detected at issue #230 , where mock users on tests remained on database, were seen through leaderboard screen to public users and HUGE BUG where database values where removed at the beginning of e2e tests.

These are the actions that I've done:

- Added a new attribute "is_test" to users, so every user is detected whenever it is a real user or a test user (identified by name (loadtest_, existing-user or new-user). These users are detected at frontend, mark as test and sent to back so backend ignore them for public access (so real users cannot see test users on leaderboard while they are accessing the app while tests are taking place).

- Removed the conflictive BeforeAll instruction on e2e test and changed for an AfterAll which only removes the new test mock users instead of the whole database (this is done via a new API instruction /deleteuser which is used with the auth of the user, so it is safe and nobody can delete other person account without current access to their account).

- Cleaning at the end of load tests via detection of "loadtest_" prefix.

I upload both the before and after of the leaderboard thanks to these changes:
<img width="1789" height="894" alt="image" src="https://github.com/user-attachments/assets/0160ac01-1415-4013-b76d-8d2c5042b562" />


<img width="1734" height="727" alt="image" src="https://github.com/user-attachments/assets/8735c7e5-9276-4abd-8163-e2cc76872b88" />
