### PR TITLE
feat: Add navigation after end of game and clarify who won

### DIFF
--- a/webapp/src/__tests__/game.test.tsx
+++ b/webapp/src/__tests__/game.test.tsx
@@ -60,6 +60,11 @@ function renderGamePage(gameId = GAME_TEST_DATA.gameId) {
   );
 }
 
+function renderFinishedGamePage(game: GameRecord) {
+  server.use(http.get(`*/games/${GAME_TEST_DATA.gameId}`, () => HttpResponse.json(game)));
+  renderGamePage();
+}
+
 // ─── loading ──────────────────────────────────────────────────────────────────
 
 describe('GamePage — loading', () => {
@@ -259,6 +264,94 @@ describe('GamePage — finish', () => {
     renderGamePage();
     await screen.findByLabelText('game board');
     expect(screen.queryByRole('button', { name: /finish/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('GamePage — finished panel', () => {
+  test('shows You as the winner after a WIN result', async () => {
+    const finishedGame: GameRecord = {
+      ...BASE_GAME,
+      status: 'FINISHED',
+      result: 'WIN',
+      moves: [{
+        move_number: 1,
+        player: 'B',
+        coordinates: { x: 2, y: 0, z: 0 },
+        created_at: new Date().toISOString()
+      }]
+    };
+
+    renderFinishedGamePage(finishedGame);
+
+    await screen.findByText(/winner: you/i);
+    expect(screen.getByRole('button', { name: /play again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /main menu/i })).toBeInTheDocument();
+  });
+
+  test('shows the enemy name as winner after a LOSS result', async () => {
+    const finishedGame: GameRecord = {
+      ...BASE_GAME,
+      status: 'FINISHED',
+      result: 'LOSS',
+      moves: [{
+        move_number: 1,
+        player: 'B',
+        coordinates: { x: 2, y: 0, z: 0 },
+        created_at: new Date().toISOString()
+      }]
+    };
+
+    renderFinishedGamePage(finishedGame);
+
+    await screen.findByText(new RegExp(`winner: ${GAME_TEST_DATA.enemyName}`, 'i'));
+  });
+
+  test('shows Bot as winner after a SURRENDERED result in bot games', async () => {
+    const finishedGame: GameRecord = {
+      ...BASE_GAME,
+      game_type: 'BOT',
+      name_of_enemy: null,
+      status: 'FINISHED',
+      result: 'SURRENDERED',
+      moves: [{
+        move_number: 1,
+        player: 'B',
+        coordinates: { x: 2, y: 0, z: 0 },
+        created_at: new Date().toISOString()
+      }]
+    };
+
+    renderFinishedGamePage(finishedGame);
+
+    await screen.findByText(/^surrendered$/i);
+  });
+
+  test('play again navigates to the new game page', async () => {
+    const finishedGame: GameRecord = {
+      ...BASE_GAME,
+      status: 'FINISHED',
+      result: 'WIN'
+    };
+
+    renderFinishedGamePage(finishedGame);
+
+    await screen.findByRole('button', { name: /play again/i });
+    await userEvent.click(screen.getByRole('button', { name: /play again/i }));
+    await screen.findByText(/new game page/i);
+  });
+
+  test('main menu navigates to the home page', async () => {
+    const finishedGame: GameRecord = {
+      ...BASE_GAME,
+      status: 'FINISHED',
+      result: 'WIN'
+    };
+
+    renderFinishedGamePage(finishedGame);
+
+    await screen.findByRole('button', { name: /main menu/i });
+    await userEvent.click(screen.getByRole('button', { name: /main menu/i }));
+    await screen.findByText(/home page/i);
   });
 });
 

--- a/webapp/src/pages/GamePage.css
+++ b/webapp/src/pages/GamePage.css
@@ -381,6 +381,35 @@
   grid-column: 1 / -1;
 }
 
+.game-result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.game-result-actions button {
+  min-width: 124px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  background: rgba(15, 23, 42, 0.2);
+  color: #ffffff;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.game-result-actions button:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.32);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.game-result-actions button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+}
+
 .game-result-box--blue {
   background: linear-gradient(135deg, #3b82f6 0%, #1e3a8a 100%);
   border: 2px solid #60a5fa;
@@ -410,4 +439,23 @@
   color: #ffffff;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
   letter-spacing: 0.05em;
+}
+
+@media (max-width: 520px) {
+  .game-result-box {
+    padding: 18px 18px;
+  }
+
+  .game-result-text {
+    font-size: 1.35rem;
+    text-align: center;
+  }
+
+  .game-result-actions {
+    width: 100%;
+  }
+
+  .game-result-actions button {
+    flex: 1 1 140px;
+  }
 }

--- a/webapp/src/pages/GamePage.tsx
+++ b/webapp/src/pages/GamePage.tsx
@@ -85,6 +85,14 @@ function getEnemyTitle(game: GameRecord): string {
   return game.name_of_enemy ?? 'Player 2 (Red)';
 }
 
+function getWinnerTitle(game: GameRecord): string {
+  if (game.result === 'WIN') {
+    return 'You';
+  }
+
+  return getEnemyTitle(game);
+}
+
 function getOwnerClass(owner: Move['player'] | null | undefined): string {
   if (owner === 'B') {
     return ' blue';
@@ -508,9 +516,11 @@ export function GamePage() {
   };
 
   const getResultText = (): string => {
-    if (game.result === 'WIN') return 'YOU WIN';
-    if (game.result === 'LOSS') return 'YOU LOSE';
-    return 'SURRENDERED';
+    if (game.result === 'SURRENDERED') {
+      return `Surrendered`;
+    }
+
+    return `Winner: ${getWinnerTitle(game)}`;
   };
 
   return (
@@ -553,6 +563,12 @@ export function GamePage() {
                 <div className={`game-result-box game-result-box--${getResultBoxClass()}`}>
                   <p className="game-result-time">{formatDuration(displayedDuration)}</p>
                   <p className="game-result-text">{getResultText()}</p>
+                  <div className="game-result-actions">
+                    <button type="button" onClick={() => navigate('/games/new')}>
+                      Play Again
+                    </button>
+                    <button type="button" onClick={() => navigate('/')}>Main Menu</button>
+                  </div>
                 </div>
               )}
             </div>

--- a/webapp/test/e2e/features/leaderboard.feature
+++ b/webapp/test/e2e/features/leaderboard.feature
@@ -14,7 +14,7 @@ Feature: Leaderboard
     And I set the board size to 3
     And I start the game
     And I play a full game until Blue wins
-    Then the game result should show "YOU WIN"
+    Then the game result should show "Winner: You"
     When I open the leaderboard page
     Then I should see the leaderboard heading
     And the leaderboard should show my username with 1 win and 1 game


### PR DESCRIPTION
This pull request improves the display and user experience for finished games on the `GamePage`. It introduces a clearer winner announcement, adds action buttons for navigation, updates styles for better usability (including on mobile), and adds comprehensive tests for these features.